### PR TITLE
Use MatrixBuffers for encode_gemm. Do not create result buffer within.

### DIFF
--- a/examples/mps/matrix-multiplication/main.rs
+++ b/examples/mps/matrix-multiplication/main.rs
@@ -40,10 +40,20 @@ fn correctness() {
 
         let a = generate_matrix::<Float32, M, K>(&device);
         let b = generate_matrix::<Float32, K, N>(&device);
-        let c = generate_matrix::<Float32, K, N>(&device);
+        let mut c = generate_matrix::<Float32, K, N>(&device);
 
         let command_buffer = command_queue.new_command_buffer();
-        encode_gemm(&device, command_buffer, false, false, &a, &b, &c, 1.0, 0.0);
+        encode_gemm(
+            &device,
+            command_buffer,
+            false,
+            false,
+            &a,
+            &b,
+            &mut c,
+            1.0,
+            0.0,
+        );
         command_buffer.commit();
         command_buffer.wait_until_completed();
 
@@ -89,7 +99,7 @@ fn performance() {
     // Generate random matrices
     let a = generate_matrix::<A, M, K>(&device);
     let b = generate_matrix::<B, K, N>(&device);
-    let c = generate_matrix::<C, K, N>(&device);
+    let mut c = generate_matrix::<C, K, N>(&device);
 
     let cases = [
         (false, false, 1.0, 0.0),
@@ -114,7 +124,7 @@ fn performance() {
                 t_right,
                 &a,
                 &b,
-                &c,
+                &mut c,
                 alpha,
                 beta,
             );

--- a/examples/mps/matrix-multiplication/main.rs
+++ b/examples/mps/matrix-multiplication/main.rs
@@ -53,7 +53,8 @@ fn correctness() {
             &mut c,
             1.0,
             0.0,
-        );
+        )
+        .expect("Encoding failed");
         command_buffer.commit();
         command_buffer.wait_until_completed();
 
@@ -127,7 +128,8 @@ fn performance() {
                 &mut c,
                 alpha,
                 beta,
-            );
+            )
+            .expect("Encoding failed");
         }
         command_buffer.commit();
         command_buffer.wait_until_completed();

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -1162,7 +1162,7 @@ pub fn encode_gemm<A, B, C>(
     transpose_right: bool,
     a: &MatrixBuffer<A>,
     b: &MatrixBuffer<B>,
-    c: &MatrixBuffer<C>,
+    c: &mut MatrixBuffer<C>,
     alpha: f64,
     beta: f64,
 ) where


### PR DESCRIPTION
Use `MatrixBuffer<T>` instead of `Matrix<T>` (and remove `Matrix<T>`).
Create buffers separately of encoding.

This improved the benchmarks as well.